### PR TITLE
Fix numpy shape disagreements

### DIFF
--- a/likelihood.py
+++ b/likelihood.py
@@ -23,8 +23,6 @@ from scipy import interpolate
 from scipy import special
 from FastPMRunner.simulationic import SimulationICs
 
-from matplotlib import pyplot as plt
-
 class Likelihood:
     """Likelihood function for the BOSS power spectrum."""
     def __init__(self):


### PR DESCRIPTION
1. Fix the shape disagreement in `def window_response(self,k_index)`
2. Fix the shape disagreement in `def loglkl` at the chi2 calculation.
  - What I did: interpolate the `powgalint` onto k bins of the covariance matrix (`self.kbins3`). But only compute the chi2 within the range of k bins in observed data (`self.k`).

Issue:
----

No numerical issue. But the power spectrum plot looks weird and `powgalint` is highly skewed at small scales.

See (bias = 0.1):
![Screenshot from 2021-04-15 20-38-25](https://user-images.githubusercontent.com/23435784/114968128-91fca200-9e2a-11eb-85fb-655a95755a01.png)

Is it reasonable?

Also, could you explain more what are the window function at here is calculating? ->
```python
        factor = np.exp(-1.*(self.kbins3*hubble/2.)**4.)*self.tmp_factor
```
